### PR TITLE
[xelatex]缺省图片文件后缀名新增其他格式

### DIFF
--- a/XDBAthesis.cls
+++ b/XDBAthesis.cls
@@ -77,7 +77,7 @@
 
 \ifpdf   % We're running pdfTeX in PDF mode
     \RequirePackage[pdftex]{hyperref}
-    \DeclareGraphicsExtensions{.pdf, .eps, .mps, .jpg, .png}
+    \DeclareGraphicsExtensions{.pdf,.eps,.mps,.jpg,.png}
 \else    % We're not running pdfTeX, or running pdfTeX in DVI mode
     \ifXDBA@dvips
         \RequirePackage[dvips]{hyperref}
@@ -89,7 +89,7 @@
     \else
         \RequirePackage[dvipdfm]{hyperref}
     \fi
-    \DeclareGraphicsExtensions{.eps,.ps}
+    \DeclareGraphicsExtensions{.eps,.ps,.mps,.pdf,.jpg,.png}
 \fi
 \hypersetup{CJKbookmarks,%
        bookmarksnumbered,%


### PR DESCRIPTION
这次把`xelatex`下的图片后缀名也给补上了，方便需要插入大量不同格式图片的童鞋
