### PR TITLE
修正make clean命令的错误提示

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,6 @@ master-utf8:
 	xelatex template-master-utf8.tex
 	xelatex template-master-utf8.tex
 clean:
-	rm *.out *.log *.toc *.aux
-	rm chapter/*.aux
-	rm chapter-utf8/*.aux
+	rm -f *.out *.log *.toc *.aux
+	rm -f chapter/*.aux 
+	rm -f chapter-utf8/*.aux


### PR DESCRIPTION
使用`rm -f`来避免当文件不存在时`make`提示`[Error 1]`
